### PR TITLE
Focus Jumping Issue

### DIFF
--- a/js/jquery.markitup.js
+++ b/js/jquery.markitup.js
@@ -163,9 +163,8 @@
 							return false;
 						}).click(function() {
 							return false;
-						}).bind("focusin", function(){
-                            $$.focus();
-						}).mouseup(function() {
+						})
+						.mouseup(function() {
 							if (button.call) {
 								eval(button.call)();
 							}
@@ -405,12 +404,12 @@
 					textarea.setSelectionRange(start, start + len);
 				}
 				textarea.scrollTop = scrollPosition;
-				textarea.focus();
+				setTimeout(function(){ textarea.focus(); }, 1);
 			}
 
 			// get the selection
 			function get() {
-				textarea.focus();
+				setTimeout(function(){ textarea.focus(); }, 1);
 
 				scrollPosition = textarea.scrollTop;
 				if (document.selection) {


### PR DESCRIPTION
Setting a timeout for focusing on the text areas, they're not instantly ready in the DOM when there are multiple on the DOM.

**Client:** Pannier 1/PANNIERL
**Job:** 1/00039279 Ongoing Support
**Phase:** 007 April
**Stage:** [98480] Issue with Journal

I've spent six hours attempting to fix this issue properly but I cannot find a _nice_ solution which can be PR'd into the Mark It Up (MIU) core.

This solution fixes the issue we have been having on our sites where there are multiple instances of the same MIU editor, however, it means that if the core is upgraded in the future, these changes will be overwritten and the CMS will most likely be broken again.
